### PR TITLE
Append semicolon to ES6 module statements

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,13 @@
+var HOOKS = [
+  'ExpressionStatement', 'VariableDeclaration', 'ReturnStatement',
+  'ContinueStatement', 'BreakStatement', 'ImportDeclaration'
+];
+var MODULE_EXPORT_HOOKS = [
+  'ExportAllDeclaration', 'ExportDefaultDeclaration', 'ExportNamedDeclaration'
+];
+
 exports.nodeBefore = function(node) {
-  if (~['ExpressionStatement', 'VariableDeclaration', 'ReturnStatement',
-    'ContinueStatement', 'BreakStatement'].indexOf(node.type)
-  ) {
+  if (shouldAppendSemicolon(node)) {
     var end = true;
     var token = node.endToken;
 
@@ -50,6 +56,27 @@ exports.nodeBefore = function(node) {
     token.value = '';
   }
 };
+
+function shouldAppendSemicolon(node) {
+  if (~HOOKS.indexOf(node.type)) {
+    return true;
+  }
+
+  if (~MODULE_EXPORT_HOOKS.indexOf(node.type)) {
+    if (!node.declaration) {
+      return true;
+    }
+
+    if (~HOOKS.concat(
+        ['Literal', 'ArrowFunctionExpression']
+      ).indexOf(node.declaration.type)
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
 
 function isEmpty(token) {
   return token && ~['WhiteSpace', 'Indent', 'LineBreak'].indexOf(token.type);

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "mocha test/*-test.js"
   },
   "devDependencies": {
-    "esformatter": "0.4.1",
+    "esformatter": "0.7.1",
     "mocha": "1.21.4"
   }
 }

--- a/test/compare-test.js
+++ b/test/compare-test.js
@@ -28,6 +28,10 @@ describe('compare input/output', function() {
     it('should be added to continue statements', function() {
       check('continue-statement');
     });
+
+    it('should be added to module import and export statements', function() {
+      check('module-statement');
+    });
   });
 
   describe('unnecessary semicolons', function() {

--- a/test/fixtures/input/module-statement.js
+++ b/test/fixtures/input/module-statement.js
@@ -1,0 +1,36 @@
+import { named1 as myNamed1, named2 } from 'src/mylib'
+import * as mylib from 'src/mylib'
+import 'src/mylib'
+
+export var myVar1 = 123
+export let myVar2 = 'foo'
+export const MY_CONST = 'BAR'
+
+export function myFunc() {
+  return 'myfunc'
+}
+
+export function* myGeneratorFunc() {
+  return yield someStuff()
+}
+export class MyClass {
+  constructor() {
+    this.name = 'exports test'
+  }
+}
+
+export default 123
+export default function (x) {
+  return x
+}
+export default x => x
+export default class {
+  constructor(x, y) {
+    this.x = x
+    this.y = y
+  }
+}
+
+export * from 'src/other_module'
+export { foo, bar } from 'src/other_module'
+export { foo as myFoo, bar } from 'src/other_module'

--- a/test/fixtures/output/module-statement.js
+++ b/test/fixtures/output/module-statement.js
@@ -1,0 +1,36 @@
+import { named1 as myNamed1, named2 } from 'src/mylib';
+import * as mylib from 'src/mylib';
+import 'src/mylib';
+
+export var myVar1 = 123;
+export let myVar2 = 'foo';
+export const MY_CONST = 'BAR';
+
+export function myFunc() {
+  return 'myfunc';
+}
+
+export function* myGeneratorFunc() {
+  return yield someStuff();
+}
+export class MyClass {
+  constructor() {
+    this.name = 'exports test';
+  }
+}
+
+export default 123;
+export default function (x) {
+  return x;
+}
+export default x => x;
+export default class {
+  constructor(x, y) {
+    this.x = x;
+    this.y = y;
+  }
+}
+
+export * from 'src/other_module';
+export { foo, bar } from 'src/other_module';
+export { foo as myFoo, bar } from 'src/other_module';


### PR DESCRIPTION
Hi,

I have added the support for ES6 module statements `import` & `export`.
I have also bumped `esformatter`'s version to support ES6 syntax.